### PR TITLE
解决底部菜单按钮在下拉时左移的问题

### DIFF
--- a/app/src/main/java/com/zibuyuqing/ucbrowser/widget/layout/UCBottomBar.java
+++ b/app/src/main/java/com/zibuyuqing/ucbrowser/widget/layout/UCBottomBar.java
@@ -66,6 +66,12 @@ public class UCBottomBar extends BaseLayout {
         if(mDirection == UCRootView.SCROLL_HORIZONTALLY){
             return;
         }
+
+        if (rate > 0) {
+            // 当下拉时，解决底部菜单按钮向左滑动的bug
+            return;
+        }
+
         //第1,2,4个按钮渐隐
         ivForward.setAlpha(calculateBtnAlpha(rate));
         ivBack.setAlpha(calculateBtnAlpha(rate));


### PR DESCRIPTION
解决在下拉时，底部菜单按钮向左移动的问题